### PR TITLE
chore: Support multi-GPU training via accelerate

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -27,6 +27,7 @@
 - [train_colbert](../train/train-colbert)
 - [train_sparse_embed](../train/train-sparse-embed)
 - [train_splade](../train/train-splade)
+- [Multi-GPU training via Accelerator](../train/multi-gpu)
 
 ## utils
 

--- a/docs/fine_tune/.pages
+++ b/docs/fine_tune/.pages
@@ -3,4 +3,5 @@ nav:
     - colbert.md
     - splade.md
     - sparse_embed.md
+    - multi_gpu.md
   

--- a/docs/fine_tune/multi_gpu.md
+++ b/docs/fine_tune/multi_gpu.md
@@ -1,0 +1,64 @@
+# Multi-GPU (Accelerator)
+
+
+Training any of the models on multiple GPU via the accelerator library is simple. You just need to modify the training loop in a few key ways:
+
+```python
+from neural_cherche import models, utils, train
+import torch
+from torch.utils.data import DataLoader
+from accelerate import Accelerator
+
+
+# Wrap in main function to avoid multiprocessing issues
+if __name__ == "__main__"":
+    accelerator = Accelerator()
+    device = accelerator.device
+    batch_size = 32
+    epochs = 2
+    save_on_epoch = True
+
+    model = models.SparseEmbed(
+        model_name_or_path="distilbert-base-uncased",
+        device=device
+    ).to(device)
+
+    # Optimizer
+    optimizer = torch.optim.AdamW(model.parameters(), lr=3e-5)
+
+    # prepare your dataset -- this example uses a huggingface `datasets` object
+    ...
+
+    # Convert the data into a PyTorch dataloader for ease of preparation
+    data_loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+    # Wrap the model, optimizer, and data loader in the accelerator
+    model, optimizer, data_loader = accelerator.prepare(model, optimizer, data_loader)
+
+    for epoch in range(epochs):
+        for batch_data in enumerate(data_loader):
+            # Assuming batch_data is a tuple in the form (anchors, positives, negatives)
+            anchors, positives, negatives = batch_data
+
+            loss = train_sparse_embed(
+                model=model,
+                optimizer=optimizer,
+                anchor=anchors,
+                positive=positives,
+                negative=negatives,
+                threshold_flops=30,
+                accelerator=accelerator,
+            )
+    
+        if accelerator.is_main_process and save_on_epoch:
+            accelerator.save_model(model, "checkpoint/epoch" + str(epoch))
+            unwrapped_model = accelerator.unwrap_model(model)
+            unwrapped_model.save_pretrained(
+            "SPARSE_EMBEDFULL/epoch" + str(epoch),
+
+    # Save at the end of the training loop
+    # We check to make sure that only the main process will export the model
+    if accelerator.is_main_process:
+        unwrapped_model = accelerator.unwrap_model(model)
+        unwrapped_model.save_pretrained("checkpoint", accelerator=True)
+```

--- a/neural_cherche/models/colbert.py
+++ b/neural_cherche/models/colbert.py
@@ -268,7 +268,7 @@ class ColBERT(Base):
 
         return torch.cat(list_scores, dim=0)
 
-    def save_pretrained(self, path: str) -> "ColBERT":
+    def save_pretrained(self, path: str, accelerator: bool = False) -> "ColBERT":
         """Save model the model.
 
         Parameters
@@ -279,7 +279,32 @@ class ColBERT(Base):
         self.model.save_pretrained(path)
         torch.save(self.linear.state_dict(), os.path.join(path, "linear.pt"))
         self.tokenizer.pad_token = self.original_pad_token
-        self.tokenizer.save_pretrained(path)
+        if accelerator:
+            # Workaround an issue with accelerator. Tokenizer has a key "device"
+            # which is non serialisable, but not removeable with a basic delattr
+
+            # dump config
+            tokenizer_config = {
+                k: v for k, v in self.tokenizer.__dict__.items() if k != "device"
+            }
+            tokenizer_config_file = os.path.join(path, "tokenizer_config.json")
+            with open(tokenizer_config_file, "w", encoding="utf-8") as file:
+                json.dump(tokenizer_config, file, ensure_ascii=False, indent=4)
+
+            # dump vocab
+            self.tokenizer.save_vocabulary(path)
+
+            # save special tokens
+            special_tokens_file = os.path.join(path, "special_tokens_map.json")
+            with open(special_tokens_file, "w", encoding="utf-8") as file:
+                json.dump(
+                    self.tokenizer.special_tokens_map,
+                    file,
+                    ensure_ascii=False,
+                    indent=4,
+                )
+        else:
+            self.tokenizer.save_pretrained(path)
         with open(os.path.join(path, "metadata.json"), "w") as f:
             json.dump(
                 {

--- a/neural_cherche/models/splade.py
+++ b/neural_cherche/models/splade.py
@@ -206,7 +206,11 @@ class Splade(Base):
 
         return {"sparse_activations": activations["sparse_activations"]}
 
-    def save_pretrained(self, path: str):
+    def save_pretrained(
+        self,
+        path: str,
+        accelerator: bool = False,
+    ):
         """Save model the model.
 
         Parameters
@@ -217,7 +221,32 @@ class Splade(Base):
         """
         self.model.save_pretrained(path)
         self.tokenizer.pad_token = self.original_pad_token
-        self.tokenizer.save_pretrained(path)
+        if accelerator:
+            # Workaround an issue with accelerator. Tokenizer has a key "device"
+            # which is non serialisable, but not removeable with a basic delattr
+
+            # dump config
+            tokenizer_config = {
+                k: v for k, v in self.tokenizer.__dict__.items() if k != "device"
+            }
+            tokenizer_config_file = os.path.join(path, "tokenizer_config.json")
+            with open(tokenizer_config_file, "w", encoding="utf-8") as file:
+                json.dump(tokenizer_config, file, ensure_ascii=False, indent=4)
+
+            # dump vocab
+            self.tokenizer.save_vocabulary(path)
+
+            # save special tokens
+            special_tokens_file = os.path.join(path, "special_tokens_map.json")
+            with open(special_tokens_file, "w", encoding="utf-8") as file:
+                json.dump(
+                    self.tokenizer.special_tokens_map,
+                    file,
+                    ensure_ascii=False,
+                    indent=4,
+                )
+        else:
+            self.tokenizer.save_pretrained(path)
 
         with open(os.path.join(path, "metadata.json"), "w") as file:
             json.dump(
@@ -306,15 +335,12 @@ class Splade(Base):
     ) -> torch.Tensor:
         """Returns activated tokens."""
         activations = torch.topk(input=sparse_activations, k=k_tokens, dim=1).indices
-
-        # Set value of max sparse_activations which are not in top k to 0.
-        sparse_activations = sparse_activations * torch.zeros(
-            (sparse_activations.shape[0], sparse_activations.shape[1]),
-            dtype=int,
-            device=self.device,
-        ).scatter_(dim=1, index=activations.long(), value=1)
+        zero_tensor = torch.zeros_like(sparse_activations, dtype=int)
+        updated_sparse_activations = sparse_activations * zero_tensor.scatter(
+            dim=1, index=activations.long(), value=1
+        )
 
         return {
             "activations": activations,
-            "sparse_activations": sparse_activations,
+            "sparse_activations": updated_sparse_activations,
         }

--- a/neural_cherche/train/train_colbert.py
+++ b/neural_cherche/train/train_colbert.py
@@ -10,6 +10,7 @@ def train_colbert(
     positive: list[str],
     negative: list[str],
     in_batch_negatives: bool = False,
+    accelerator=None,
     **kwargs,
 ):
     """Compute the ranking loss and the flops loss for a single step.
@@ -98,7 +99,10 @@ def train_colbert(
 
     loss = losses.Ranking()(**scores)
 
-    loss.backward()
+    if accelerator:
+        accelerator.backward(loss)
+    else:
+        loss.backward()
     optimizer.step()
     optimizer.zero_grad()
 

--- a/neural_cherche/train/train_sparse_embed.py
+++ b/neural_cherche/train/train_sparse_embed.py
@@ -16,6 +16,7 @@ def train_sparse_embed(
     dense_loss_weight: float = 1.0,
     in_batch_negatives: bool = False,
     threshold_flops: float = 30,
+    accelerator=None,
     **kwargs,
 ):
     """Compute the ranking loss and the flops loss for a single step.
@@ -147,7 +148,10 @@ def train_sparse_embed(
         + flops_loss_weight * flops_loss
     )
 
-    loss.backward()
+    if accelerator:
+        accelerator.backward(loss)
+    else:
+        loss.backward()
     optimizer.step()
     optimizer.zero_grad()
 

--- a/neural_cherche/train/train_splade.py
+++ b/neural_cherche/train/train_splade.py
@@ -13,6 +13,7 @@ def train_splade(
     sparse_loss_weight: float = 1.0,
     in_batch_negatives: bool = False,
     threshold_flops: float = 30,
+    accelerator=None,
     **kwargs,
 ):
     """Compute the ranking loss and the flops loss for a single step.
@@ -117,7 +118,10 @@ def train_splade(
 
     loss = sparse_loss_weight * sparse_loss + flops_loss_weight * flops_loss
 
-    loss.backward()
+    if accelerator:
+        accelerator.backward(loss)
+    else:
+        loss.backward()
     optimizer.step()
     optimizer.zero_grad()
 


### PR DESCRIPTION
Hey! Great work on the library. I've been playing with it and ran into a few issues with in-place operations when trying to train on multiple GPUs:

- BERT as implemented on HuggingFace has [a known issue](https://github.com/huggingface/accelerate/issues/97) (this was really annoying to find) where it needs explicit position_ids to run on multi-gpu
- The scatter_() call to update activations was a bit finnicky

Setting device this way also really doesn't play nice with the default tokeniser export, so there's a workaround to export the files individually rather than risky JSON decoding.

I've also added a doc page to show how simple it is to parallelise training with just those few changes and some very slightly code modifications in a trading script.