### PR TITLE
chore: Allow custom prefixes

### DIFF
--- a/neural_cherche/models/base.py
+++ b/neural_cherche/models/base.py
@@ -24,10 +24,15 @@ class Base(ABC, torch.nn.Module):
         model_name_or_path: str,
         device: str = None,
         extra_files_to_load: list[str] = [],
+        query_prefix: str = "[Q] ",
+        document_prefix: str = "[D] ",
         **kwargs,
     ) -> None:
         """Initialize the model."""
         super(Base, self).__init__()
+
+        self.query_prefix = query_prefix
+        self.document_prefix = document_prefix
 
         if device is not None:
             self.device = device

--- a/neural_cherche/models/colbert.py
+++ b/neural_cherche/models/colbert.py
@@ -95,6 +95,8 @@ class ColBERT(Base):
         device: str = None,
         max_length_query: int = 32,
         max_length_document: int = 350,
+        query_prefix: str = "[Q] ",
+        document_prefix: str = "[D] ",
         **kwargs,
     ) -> None:
         """Initialize the model."""
@@ -102,6 +104,8 @@ class ColBERT(Base):
             model_name_or_path=model_name_or_path,
             device=device,
             extra_files_to_load=["linear.pt", "metadata.json"],
+            query_prefix=query_prefix,
+            document_prefix=document_prefix,
             **kwargs,
         )
 
@@ -182,9 +186,9 @@ class ColBERT(Base):
         query_mode
             Wether to encode query or not.
         """
-        suffix = "[Q] " if query_mode else "[D] "
+        prefix = self.query_prefix if query_mode else self.document_prefix
 
-        texts = [suffix + text for text in texts]
+        texts = [prefix + text for text in texts]
 
         self.tokenizer.pad_token = (
             self.query_pad_token if query_mode else self.original_pad_token

--- a/neural_cherche/models/colbert.py
+++ b/neural_cherche/models/colbert.py
@@ -136,6 +136,8 @@ class ColBERT(Base):
                 metadata = json.load(f)
             self.max_length_document = metadata["max_length_document"]
             self.max_length_query = metadata["max_length_query"]
+            self.query_prefix = metadata.get("query_prefix", self.query_prefix)
+            self.document_prefix = metadata.get("document_prefix", self.document_prefix)
 
         if os.path.exists(os.path.join(self.model_folder, "linear.pt")):
             self.linear.load_state_dict(linear)
@@ -289,6 +291,8 @@ class ColBERT(Base):
                 {
                     "max_length_query": self.max_length_query,
                     "max_length_document": self.max_length_document,
+                    "query_prefix": self.query_prefix,
+                    "document_prefix": self.document_prefix,
                 },
                 f,
             )

--- a/neural_cherche/models/sparse_embed.py
+++ b/neural_cherche/models/sparse_embed.py
@@ -97,12 +97,16 @@ class SparseEmbed(Splade):
         max_length_query: int = 128,
         max_length_document: int = 256,
         device: str = None,
+        query_prefix: str = "[Q] ",
+        document_prefix: str = "[D] ",
         **kwargs,
     ) -> None:
         super(SparseEmbed, self).__init__(
             model_name_or_path=model_name_or_path,
             device=device,
             extra_files_to_load=["linear.pt", "metadata.json"],
+            query_prefix=query_prefix,
+            document_prefix=document_prefix,
             **kwargs,
         )
 
@@ -156,9 +160,9 @@ class SparseEmbed(Splade):
         query_mode
             Whether to encode queries or documents.
         """
-        suffix = "[Q] " if query_mode else "[D] "
+        prefix = self.query_prefix if query_mode else self.document_prefix
 
-        texts = [suffix + text for text in texts]
+        texts = [prefix + text for text in texts]
 
         self.tokenizer.pad_token = (
             self.query_pad_token if query_mode else self.original_pad_token

--- a/neural_cherche/models/sparse_embed.py
+++ b/neural_cherche/models/sparse_embed.py
@@ -141,6 +141,8 @@ class SparseEmbed(Splade):
 
             max_length_query = metadata["max_length_query"]
             max_length_document = metadata["max_length_document"]
+            self.query_prefix = metadata.get("query_prefix", self.query_prefix)
+            self.document_prefix = metadata.get("document_prefix", self.document_prefix)
 
         self.max_length_query = max_length_query
         self.max_length_document = max_length_document
@@ -228,6 +230,8 @@ class SparseEmbed(Splade):
                 obj={
                     "max_length_query": self.max_length_query,
                     "max_length_document": self.max_length_document,
+                    "query_prefix": self.query_prefix,
+                    "document_prefix": self.document_prefix,
                 },
                 indent=4,
             )

--- a/neural_cherche/models/splade.py
+++ b/neural_cherche/models/splade.py
@@ -80,12 +80,16 @@ class Splade(Base):
         max_length_query: int = 128,
         max_length_document: int = 256,
         extra_files_to_load: list[str] = ["metadata.json"],
+        query_prefix: str = "[Q] ",
+        document_prefix: str = "[D] ",
         **kwargs,
     ) -> None:
         super(Splade, self).__init__(
             model_name_or_path=model_name_or_path,
             device=device,
             extra_files_to_load=extra_files_to_load,
+            query_prefix=query_prefix,
+            document_prefix=document_prefix,
             **kwargs,
         )
 
@@ -178,9 +182,9 @@ class Splade(Base):
         query_mode
             Whether to encode queries or documents.
         """
-        suffix = "[Q] " if query_mode else "[D] "
+        prefix = self.query_prefix if query_mode else self.document_prefix
 
-        texts = [suffix + text for text in texts]
+        texts = [prefix + text for text in texts]
 
         self.tokenizer.pad_token = (
             self.query_pad_token if query_mode else self.original_pad_token

--- a/neural_cherche/models/splade.py
+++ b/neural_cherche/models/splade.py
@@ -101,6 +101,8 @@ class Splade(Base):
 
             max_length_query = metadata["max_length_query"]
             max_length_document = metadata["max_length_document"]
+            self.query_prefix = metadata.get("query_prefix", self.query_prefix)
+            self.document_prefix = metadata.get("document_prefix", self.document_prefix)
 
         self.max_length_query = max_length_query
         self.max_length_document = max_length_document
@@ -229,6 +231,8 @@ class Splade(Base):
                 obj={
                     "max_length_query": self.max_length_query,
                     "max_length_document": self.max_length_document,
+                    "query_prefix": self.query_prefix,
+                    "document_prefix": self.document_prefix,
                 },
                 indent=4,
             )


### PR DESCRIPTION
Another small PR, but potentially useful (at least to me, when working with non-latin languages).

The aim is to use a model argument/metadata to store the query_prefix/document_prefix, as it can be useful when:
- Using a model that's already trained for certain prefixes as weight initialisation (e.g. e5 or bge for ColBERTV2, as they both have a pre-defined query prefix they're already trained on)
- Allow you to use a more language/tokenizer-appropriate one in certain cases (e.g. I'm currently working on Japanese data, where a lot of latin expressions map to `<UNK>`)