### PR TITLE
[bug] no query_mode argument for sentence transformers encode

### DIFF
--- a/neural_cherche/models/colbert.py
+++ b/neural_cherche/models/colbert.py
@@ -252,13 +252,11 @@ class ColBERT(Base):
         ):
             queries_embeddings = self.encode(
                 texts=batch_queries,
-                query_mode=True,
                 **kwargs,
             )
 
             documents_embeddings = self.encode(
                 texts=batch_documents,
-                query_mode=False,
                 **kwargs,
             )
 


### PR DESCRIPTION
I haven't been able to find any documentation on the `query_mode` argument to `encode`.  I believe this is the right fix.